### PR TITLE
Fixed preview selectors. Fixes #10

### DIFF
--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -1,7 +1,8 @@
 const qs = document.querySelector.bind(document);
 
 export function getAuthenticityToken() {
-    return qs('input[name="authenticity_token"]').value;
+    return qs('.timeline-comment > .js-previewable-comment-form')
+        .getAttribute('data-preview-authenticity-token');
 }
 
 export function getComment(form) {
@@ -9,7 +10,7 @@ export function getComment(form) {
 }
 
 export function getPreviewUri() {
-    return qs('.js-previewable-comment-form')
+    return qs('.timeline-comment > .js-previewable-comment-form')
         .getAttribute('data-preview-url');
 }
 


### PR DESCRIPTION
Github changed the field that has the preview url and key, so this updates the selectors to point at the correct fields. Tested on this PR, PR comments, and on issue comments.