### PR TITLE
Add explicit permissions for GitHub sites

### DIFF
--- a/shells/chrome/manifest.json
+++ b/shells/chrome/manifest.json
@@ -3,6 +3,10 @@
     "version": "1.0.2",
     "description": "Live preview for markdown comments in PRs/Issues on GitHub",
     "manifest_version": 2,
+    "permissions": [
+        "https://github.com",
+        "https://gist.github.com"
+    ],
     "content_scripts": [{
         "matches": ["*://*/*"],
         "js": ["inject.js"],


### PR DESCRIPTION
This PR updates the extension permissions so that it only requests to read & change data on GitHub sites

Closes #12